### PR TITLE
update to awssdkv3; expose the low-level client

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ npm i fastify-dynamodb -S
 ```
 ## Usage
 Add it to you project with `register` and you are done!  
-You can access the *DynamoDB DocumentClient* via `fastify.dynamo`.
+You can access the [*DynamoDB DocumentClient*](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/modules/_aws_sdk_lib_dynamodb.html) via `fastify.dynamo`. The [low-level client](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-dynamodb/index.html) is also available via `fastify.dynamoClient`.
 ```js
-const fastify = require('fastify')
+const fastify = require('fastify')()
 
 fastify.register(require('fastify-dynamodb'), {
     endpoint: 'http://localhost:8000',
@@ -26,9 +26,12 @@ fastify.listen(3000, err => {
 })
 ```
 
-In your route file you can simply do all gets, queries, scans e.g.:
+In your route file you can use the dynamodb client to perform queries:
+For further documentation on querying, see the [DynamoDBDocumentClient docs](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/dynamodb-example-dynamodb-utilities.html).
 
 ```js
+const { GetCommand } = require("@aws-sdk/lib-dynamodb")
+
 async function singleRoute(fastify, options) {
   fastify.get(
     '/users/:id',
@@ -42,7 +45,7 @@ async function singleRoute(fastify, options) {
         },
       };
       try {
-        data = await fastify.dynamo.get(params).promise();
+        data = await fastify.dynamo.send(new GetCommand(params));
       } catch (e) {
          reply.send(e)
       }

--- a/package.json
+++ b/package.json
@@ -27,15 +27,16 @@
   },
   "homepage": "https://github.com/matrus2/fastify-dynamodb#readme",
   "dependencies": {
-    "aws-sdk": "^2.475.0",
-    "fastify": "^3.1.1",
-    "fastify-plugin": "^0.2.2"
+    "@aws-sdk/client-dynamodb": "^3.289.0",
+    "@aws-sdk/lib-dynamodb": "^3.289.0",
+    "fastify-plugin": "^4.5.0"
   },
   "engines": {
     "node": ">=8.0.0"
   },
   "devDependencies": {
-    "standard": "^10.0.3",
-    "tap": "^14.2.2"
+    "fastify": "^4.14.1",
+    "standard": "^17.0.0",
+    "tap": "^16.3.4"
   }
 }

--- a/test.js
+++ b/test.js
@@ -3,9 +3,7 @@ const test = t.test
 const Fastify = require('fastify')
 const fastifyDynamoDB = require('./index')
 
-test('fastify.db should exist', t => {
-  t.plan(3)
-
+test('fastify.dynamo and fastify.dynamoClient should exist', t => {
   const fastify = Fastify()
 
   fastify.register(fastifyDynamoDB, {
@@ -18,6 +16,8 @@ test('fastify.db should exist', t => {
   fastify.ready(err => {
     t.error(err)
     t.ok(fastify.dynamo)
+    t.ok(fastify.dynamoClient)
     fastify.close()
+    t.end()
   })
 })


### PR DESCRIPTION
Updated to awssdk v3, and also updated to the latest fastify version.
I suggest publishing this as a new major version.